### PR TITLE
Defsystem needs a qualified package (or a wrapper package).

### DIFF
--- a/code/petalisp.asd
+++ b/code/petalisp.asd
@@ -1,4 +1,4 @@
-(defsystem :petalisp
+(asdf:defsystem :petalisp
   :description "Elegant High Performance Computing"
   :author "Marco Heisig <marco.heisig@fau.de>"
   :license "AGPLv3"


### PR DESCRIPTION
This fixes compiler errors when `compile`ing the ASD. The following snippet is an ugly alternative to get `asdf:defsystem` locally used.
```lisp
(defpackage :petalisp-wrapper
  (:use :cl :asdf)) ; Alternative to qualifying
(in-package :petalisp-wrapper)
(defsystem :petalisp
    ...)
```
