### PR TITLE
Remove assertion that storage-buffer must fulfill `arrayp`

### DIFF
--- a/code/scheduler/scheduler.lisp
+++ b/code/scheduler/scheduler.lisp
@@ -30,7 +30,6 @@
           (if (immediatep lazy-array)
               lazy-array
               (let ((storage (petalisp.ir:buffer-storage root-buffer)))
-                (assert (arrayp storage))
                 (lazy-array storage))))))
 
 ;;; Return a suitable next slice, or NIL, if all work is done.


### PR DESCRIPTION
This allows backend developers to use non-lisp types as storage as long as their type implement `lazy-array`.