### PR TITLE
Fix petalisp.examples.machine-learning:make-convolutional-layer

### DIFF
--- a/examples/machine-learning.lisp
+++ b/examples/machine-learning.lisp
@@ -99,7 +99,7 @@
               (maxf (aref upper-bounds index) offset)))
     ;; Use the bounding box to compute the shape of the result.
     (let ((result-shape
-            (~ 0 ~l
+            (~ 1 ~l
                (loop for lb across lower-bounds
                      for ub across upper-bounds
                      for range in (shape-ranges (array-shape array))


### PR DESCRIPTION
~ 1 instead of ~ 0 has to be used now to obtain a one element iteration
range in one dimension. ~ 0 anywhere within a shape descriptor leads to an empty shape.