### PR TITLE
Fix loading of multicore-backend for non-sbcl implementations

### DIFF
--- a/code/multicore-backend/multicore-backend.lisp
+++ b/code/multicore-backend/multicore-backend.lisp
@@ -35,7 +35,7 @@
 
 (deftype atomic-counter ()
   #+sbcl 'sb-ext:word
-  #-sbcl fixnum)
+  #-sbcl 'fixnum)
 
 (defstruct request
   ;; The backend to which this request was made.


### PR DESCRIPTION
Type specifier in deftype has to be quoted.
This is needed for loading Petalisp with ccl.