### PR TITLE
Fix backend-wait for native-backend

### DIFF
--- a/code/native-backend/native-backend.lisp
+++ b/code/native-backend/native-backend.lisp
@@ -53,5 +53,5 @@
 
 (defmethod backend-wait
     ((backend native-backend)
-     (promise t))
-  (lparallel.promise:force promise))
+     (requests list))
+  (mapcar #'lparallel.promise:force requests))


### PR DESCRIPTION
Forcing the list of promises won't wait for them.

```lisp
;;; The generic function BACKEND-WAIT receives as its second argument a
;;; list of objects that have been returned by earlier calls to
;;; BACKEND-SCHEDULE.  It blocks until all the corresponding operations
;;; have been performed.
(defgeneric backend-wait (backend requests))
```